### PR TITLE
Added ruby time

### DIFF
--- a/src/main/java/com/metamx/common/parsers/TimestampParser.java
+++ b/src/main/java/com/metamx/common/parsers/TimestampParser.java
@@ -98,6 +98,18 @@ public class TimestampParser
           return new DateTime(Long.parseLong(ParserUtils.stripQuotes(input)) * 1000);
         }
       };
+    } else if (format.equalsIgnoreCase("ruby")) {
+      return new Function<String, DateTime>()
+      {
+        @Override
+        public DateTime apply(String input)
+        {
+          Preconditions.checkArgument(input != null && !input.isEmpty(), "null timestamp");
+          Double ts = Double.parseDouble(ParserUtils.stripQuotes(input));
+          Long jts = ts.longValue() * 1000; // ignoring milli secs
+          return new DateTime(jts);
+        }
+      };
     } else if (format.equalsIgnoreCase("millis")) {
       return new Function<String, DateTime>()
       {

--- a/src/test/java/com/metamx/common/parsers/TimestampParserTest.java
+++ b/src/test/java/com/metamx/common/parsers/TimestampParserTest.java
@@ -23,6 +23,12 @@ public class TimestampParserTest
     Assert.assertEquals(new DateTime("2009-02-13T23:31:30Z"), parser.apply("2009-02-13T23:31:30Z"));
   }
 
+  @Test
+  public void testRuby() throws Exception {
+    final Function<String, DateTime> parser = ParserUtils.createTimestampParser("ruby");
+    Assert.assertEquals(new DateTime("2013-01-16T15:41:47+01:00"), parser.apply("1358347307.435447"));
+  }
+
   /*Commenting out until Joda 2.1 supported
   @Test
   public void testTimeStampParserWithQuotes() throws Exception {


### PR DESCRIPTION
ruby people like to store their posix timestamps as doubles. I added a new ruby time. It's ignoring decimals for now, but that should be fine anyhow.
