### PR TITLE
Replace invalid unicode code points during parsing.

### DIFF
--- a/src/test/java/com/metamx/common/parsers/JSONParserTest.java
+++ b/src/test/java/com/metamx/common/parsers/JSONParserTest.java
@@ -9,7 +9,8 @@ import java.util.Map;
 
 public class JSONParserTest
 {
-  final String json = "{\"one\": \"foo\", \"two\" : [\"bar\", \"baz\"], \"three\" : \"qux\", \"four\" : null}";
+  private static final String json = "{\"one\": \"foo\", \"two\" : [\"bar\", \"baz\"], \"three\" : \"qux\", \"four\" : null}";
+  private static final String whackyCharacterJson = "{\"one\": \"foo\\uD900\"}";
 
   @Test
   public void testSimple()
@@ -19,6 +20,18 @@ public class JSONParserTest
     Assert.assertEquals(
         "jsonMap",
         ImmutableMap.of("one", "foo", "two", ImmutableList.of("bar", "baz"), "three", "qux"),
+        jsonMap
+    );
+  }
+
+  @Test
+  public void testWithWhackyCharacters()
+  {
+    final Parser<String, Object> jsonParser = new JSONParser();
+    final Map<String, Object> jsonMap = jsonParser.parse(whackyCharacterJson);
+    Assert.assertEquals(
+        "jsonMap",
+        ImmutableMap.of("one", "foo?"),
         jsonMap
     );
   }


### PR DESCRIPTION
Invalid code points can cause unexpected problems when ordering of strings matters, e.g.

```
Error: com.metamx.common.ISE: Value[?try}-es; GT-I9300] is less than the last value[zigorat1s] I have, cannot be.
    at io.druid.segment.IndexMerger$DimValueConverter.convert(IndexMerger.java:911)
    at io.druid.segment.IndexMerger.makeIndexFiles(IndexMerger.java:508)
    at io.druid.segment.IndexMerger.merge(IndexMerger.java:308)
    at io.druid.segment.IndexMerger.mergeQueryableIndex(IndexMerger.java:170)
    at io.druid.indexer.IndexGeneratorJob$IndexGeneratorReducer.reduce(IndexGeneratorJob.java:376)
    at io.druid.indexer.IndexGeneratorJob$IndexGeneratorReducer.reduce(IndexGeneratorJob.java:253)
    at org.apache.hadoop.mapreduce.Reducer.run(Reducer.java:171)
    at org.apache.hadoop.mapred.ReduceTask.runNewReducer(ReduceTask.java:627)
    at org.apache.hadoop.mapred.ReduceTask.run(ReduceTask.java:389)
    at org.apache.hadoop.mapred.YarnChild$2.run(YarnChild.java:167)
    at java.security.AccessController.doPrivileged(Native Method)
    at javax.security.auth.Subject.doAs(Subject.java:415)
    at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1548)
    at org.apache.hadoop.mapred.YarnChild.main(YarnChild.java:162)
```
