### PR TITLE
Add and maybe start handler instead of add.

### DIFF
--- a/src/main/java/com/metamx/common/concurrent/ExecutorServices.java
+++ b/src/main/java/com/metamx/common/concurrent/ExecutorServices.java
@@ -16,6 +16,7 @@
 
 package com.metamx.common.concurrent;
 
+import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.metamx.common.lifecycle.Lifecycle;
 
@@ -37,22 +38,26 @@ public class ExecutorServices
 
   public static <T extends ExecutorService> T manageLifecycle(Lifecycle lifecycle, final T service)
   {
-    lifecycle.addHandler(
-        new Lifecycle.Handler()
-        {
-          @Override
-          public void start() throws Exception
+    try {
+      lifecycle.addMaybeStartHandler(
+          new Lifecycle.Handler()
           {
-          }
+            @Override
+            public void start() throws Exception
+            {
+            }
 
-          @Override
-          public void stop()
-          {
-            service.shutdownNow();
+            @Override
+            public void stop()
+            {
+              service.shutdownNow();
+            }
           }
-        }
-    );
-
+      );
+    }
+    catch (Exception e) {
+      Throwables.propagate(e);
+    }
     return service;
   }
 }


### PR DESCRIPTION
Exception will raise if the service did already start

Basically, what is happening is that we have implemented a class that uses the ScheduledExecutorFactory to generate its own executors. This is done after initialization, though, so the Lifecycle has already been started. The method that is being used here to register things on the Lifecycle can only be used before it has been started. This PR is changing it to the method that can work even if the Lifecycle has already been started.

The big difference in the API is that it throws an exception, which must now be handled. Now, the only way that an exception is thrown is if the start() method throws it, the start() method does nothing here so it will not actually get thrown. Either way, we just propagate.