### PR TITLE
Add nanosecond timestamp parsing

### DIFF
--- a/src/main/java/com/metamx/common/parsers/TimestampParser.java
+++ b/src/main/java/com/metamx/common/parsers/TimestampParser.java
@@ -92,6 +92,16 @@ public class TimestampParser
           return new DateTime(Long.parseLong(ParserUtils.stripQuotes(input)));
         }
       };
+    } else if (format.equalsIgnoreCase("nano")) {
+      return new Function<String, DateTime>() {
+        @Override
+        public DateTime apply(String input) {
+          Preconditions.checkArgument(input != null && !input.isEmpty(), "null timestamp");
+          long timeNs = Long.parseLong(ParserUtils.stripQuotes(input));
+          // Convert to milliseconds, effectively: ms = floor(time in ns / 1000000)
+          return new DateTime(timeNs / 1000000L);
+        }
+      };
     } else {
       try {
         final DateTimeFormatter formatter = DateTimeFormat.forPattern(format);

--- a/src/test/java/com/metamx/common/parsers/TimestampParserTest.java
+++ b/src/test/java/com/metamx/common/parsers/TimestampParserTest.java
@@ -45,6 +45,21 @@ public class TimestampParserTest
     Assert.assertEquals(new DateTime("2013-01-16T15:41:47+01:00"), parser.apply("1358347307.435447"));
   }
 
+  @Test
+  public void testNano() throws Exception {
+    String timeNsStr = "1427504794977098494";
+    DateTime expectedDt = new DateTime("2015-3-28T01:06:34.977Z");
+    final Function<String, DateTime> parser = ParserUtils.createTimestampParser("nano");
+    Assert.assertEquals("Incorrect truncation of nanoseconds -> milliseconds",
+        expectedDt, parser.apply(timeNsStr));
+
+    // Confirm sub-millisecond timestamps are handled correctly
+    expectedDt = new DateTime("1970-1-1T00:00:00.000Z");
+    Assert.assertEquals(expectedDt, parser.apply("999999"));
+    Assert.assertEquals(expectedDt, parser.apply("0"));
+    Assert.assertEquals(expectedDt, parser.apply("0000"));
+  }
+
   /*Commenting out until Joda 2.1 supported
   @Test
   public void testTimeStampParserWithQuotes() throws Exception {


### PR DESCRIPTION
The nano timestamp parser is very basic -- it will truncate (rather
than round) a timestamp in nanoseconds to milliseconds before
returning a new DateTime representing the timestamp.