### PR TITLE
Add flush calls to StreamUtils to handle errors on buffered stream flushes

### DIFF
--- a/src/main/java/com/metamx/common/StreamUtils.java
+++ b/src/main/java/com/metamx/common/StreamUtils.java
@@ -55,7 +55,9 @@ public class StreamUtils
   {
     file.getParentFile().mkdirs();
     try (OutputStream os = new BufferedOutputStream(new FileOutputStream(file))) {
-      return ByteStreams.copy(is, os);
+      final long result =  ByteStreams.copy(is, os);
+      os.flush();
+      return result;
     }
     finally {
       CloseQuietly.close(is);
@@ -79,7 +81,9 @@ public class StreamUtils
   {
     file.getParentFile().mkdirs();
     try (OutputStream os = new BufferedOutputStream(new FileOutputStream(file))) {
-      return copyWithTimeout(is, os, timeout);
+      final long retval = copyWithTimeout(is, os, timeout);
+      os.flush();
+      return retval;
     }
     finally {
       CloseQuietly.close(is);
@@ -99,7 +103,9 @@ public class StreamUtils
   public static long copyAndClose(InputStream is, OutputStream os) throws IOException
   {
     try {
-      return ByteStreams.copy(is, os);
+      final long retval = ByteStreams.copy(is, os);
+      os.flush();
+      return retval;
     }
     finally {
       CloseQuietly.close(is);
@@ -133,6 +139,7 @@ public class StreamUtils
       os.write(buffer, 0, n);
       size += n;
     }
+    os.flush();
     return size;
   }
 
@@ -163,7 +170,9 @@ public class StreamUtils
               try {
                 inputStream = byteSource.openStream();
                 outputStream = byteSink.openStream();
-                return ByteStreams.copy(inputStream, outputStream);
+                final long retval =  ByteStreams.copy(inputStream, outputStream);
+                outputStream.flush();
+                return retval;
               }
               finally {
                 CloseQuietly.close(inputStream);

--- a/src/test/java/com/metamx/common/StreamUtilsTest.java
+++ b/src/test/java/com/metamx/common/StreamUtilsTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2011 - 2015 Metamarkets Group Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.metamx.common;
+
+import com.google.common.io.ByteSink;
+import com.google.common.io.ByteSource;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Random;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class StreamUtilsTest
+{
+  @Rule
+  public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @Test
+  public void testRetryExceptionOnFlush()
+  {
+    final byte[] bytes = new byte[1 << 10];
+    Random random = new Random(47831947819L);
+    random.nextBytes(bytes);
+    final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    final AtomicLong outputFlushes = new AtomicLong(0);
+    Assert.assertEquals(
+        bytes.length,
+        StreamUtils.retryCopy(
+            new ByteSource()
+            {
+              @Override
+              public InputStream openStream() throws IOException
+              {
+                return new ByteArrayInputStream(bytes);
+              }
+            },
+            new ByteSink()
+            {
+              @Override
+              public OutputStream openStream() throws IOException
+              {
+                byteArrayOutputStream.reset();
+                return new FilterOutputStream(byteArrayOutputStream)
+                {
+                  @Override
+                  public void flush() throws IOException
+                  {
+                    if (outputFlushes.getAndIncrement() > 0) {
+                      out.flush();
+                    } else {
+                      throw new IOException("Test exception");
+                    }
+                  }
+                };
+              }
+            },
+            FileUtils.IS_EXCEPTION,
+            10
+        )
+    );
+    Assert.assertEquals(4, outputFlushes.get());// 2 closes and 2 manual flushes
+    Assert.assertArrayEquals(bytes, byteArrayOutputStream.toByteArray());
+  }
+  @Test(expected = IOException.class)
+  public void testTimeoutCopyExceptionOnFlush() throws IOException, TimeoutException
+  {
+    final byte[] bytes = new byte[1 << 10];
+    Random random = new Random(47831947819L);
+    random.nextBytes(bytes);
+    final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    final AtomicLong outputFlushes = new AtomicLong(0);
+    StreamUtils.copyWithTimeout(
+        new ByteArrayInputStream(bytes),
+        new FilterOutputStream(byteArrayOutputStream)
+        {
+          @Override
+          public void flush() throws IOException
+          {
+            if (outputFlushes.getAndIncrement() > 0) {
+              out.flush();
+            } else {
+              throw new IOException("Test exception");
+            }
+          }
+        },
+        1 << 10
+    );
+  }
+}


### PR DESCRIPTION
The new unit tests fail without the extra flush calls.