### PR TITLE
Add flush calls in CompressionUtils to help ensure that flush errors are thrown properly

### DIFF
--- a/src/main/java/com/metamx/common/CompressionUtils.java
+++ b/src/main/java/com/metamx/common/CompressionUtils.java
@@ -99,6 +99,7 @@ public class CompressionUtils
         totalSize += Files.asByteSource(file).copyTo(zipOut);
       }
       zipOut.closeEntry();
+      zipOut.flush();
     }
 
     return totalSize;
@@ -317,7 +318,9 @@ public class CompressionUtils
   public static long gunzip(InputStream in, OutputStream out) throws IOException
   {
     try (GZIPInputStream gzipInputStream = gzipInputStream(in)) {
-      return ByteStreams.copy(gzipInputStream, out);
+      final long result =  ByteStreams.copy(gzipInputStream, out);
+      out.flush();
+      return result;
     }
     finally {
       out.close();
@@ -382,7 +385,9 @@ public class CompressionUtils
   public static long gzip(InputStream inputStream, OutputStream out) throws IOException
   {
     try (GZIPOutputStream outputStream = new GZIPOutputStream(out)) {
-      return ByteStreams.copy(inputStream, outputStream);
+      final long result = ByteStreams.copy(inputStream, outputStream);
+      out.flush();
+      return result;
     }
     finally {
       CloseQuietly.close(out);


### PR DESCRIPTION
This should not be merged until
https://github.com/metamx/java-util/pull/24
is in because the unit tests will not pass.