### PR TITLE
avoid string conversion while doing timestamp parsing whenever possible

### DIFF
--- a/src/test/java/com/metamx/common/parsers/TimestampParserTest.java
+++ b/src/test/java/com/metamx/common/parsers/TimestampParserTest.java
@@ -17,9 +17,7 @@
 package com.metamx.common.parsers;
 
 import com.google.common.base.Function;
-import org.joda.time.Chronology;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -34,22 +32,24 @@ public class TimestampParserTest
 
   @Test
   public void testAuto() throws Exception {
-    final Function<String, DateTime> parser = ParserUtils.createTimestampParser("auto");
+    final Function<Object, DateTime> parser = TimestampParser.createObjectTimestampParser("auto");
     Assert.assertEquals(new DateTime("2009-02-13T23:31:30Z"), parser.apply("1234567890000"));
     Assert.assertEquals(new DateTime("2009-02-13T23:31:30Z"), parser.apply("2009-02-13T23:31:30Z"));
+    Assert.assertEquals(new DateTime("2009-02-13T23:31:30Z"), parser.apply(1234567890000L));
   }
 
   @Test
   public void testRuby() throws Exception {
-    final Function<String, DateTime> parser = ParserUtils.createTimestampParser("ruby");
+    final Function<Object, DateTime> parser = TimestampParser.createObjectTimestampParser("ruby");
     Assert.assertEquals(new DateTime("2013-01-16T15:41:47+01:00"), parser.apply("1358347307.435447"));
+    Assert.assertEquals(new DateTime("2013-01-16T15:41:47+01:00"), parser.apply(1358347307.435447D));
   }
 
   @Test
   public void testNano() throws Exception {
     String timeNsStr = "1427504794977098494";
     DateTime expectedDt = new DateTime("2015-3-28T01:06:34.977Z");
-    final Function<String, DateTime> parser = ParserUtils.createTimestampParser("nano");
+    final Function<Object, DateTime> parser = TimestampParser.createObjectTimestampParser("nano");
     Assert.assertEquals("Incorrect truncation of nanoseconds -> milliseconds",
         expectedDt, parser.apply(timeNsStr));
 
@@ -58,6 +58,7 @@ public class TimestampParserTest
     Assert.assertEquals(expectedDt, parser.apply("999999"));
     Assert.assertEquals(expectedDt, parser.apply("0"));
     Assert.assertEquals(expectedDt, parser.apply("0000"));
+    Assert.assertEquals(expectedDt, parser.apply(999999L));
   }
 
   /*Commenting out until Joda 2.1 supported


### PR DESCRIPTION
avoid string conversion while doing timestamp parsing whenever possible. 
