### PR TITLE
Change Logger to not try to interpret messages with no args

### DIFF
--- a/src/main/java/com/metamx/common/logger/Logger.java
+++ b/src/main/java/com/metamx/common/logger/Logger.java
@@ -110,6 +110,9 @@ public class Logger
 
   private String safeFormat(String message, Object... formatArgs)
   {
+    if(formatArgs == null || formatArgs.length == 0) {
+      return message;
+    }
     try {
       return String.format(message, formatArgs);
     }

--- a/src/test/java/com/metamx/common/logger/LoggerTest.java
+++ b/src/test/java/com/metamx/common/logger/LoggerTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2015 Metamarkets Group Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.metamx.common.logger;
+
+import org.junit.Test;
+
+public class LoggerTest
+{
+  @Test
+  public void testLogWithCrazyMessages()
+  {
+    final String message = "this % might %d kill %*.s the %s parser";
+    final Logger log = new Logger(LoggerTest.class);
+    log.warn(message);
+  }
+}


### PR DESCRIPTION
* Fixes problems where people log by doing `log.info(message)` and `message` contains special formatting characters