### PR TITLE
Add @Deprecated catch for logging assuming slf4j convention

### DIFF
--- a/src/main/java/com/metamx/common/logger/Logger.java
+++ b/src/main/java/com/metamx/common/logger/Logger.java
@@ -77,6 +77,16 @@ public class Logger
     }
   }
 
+  /**
+   * Protect against assuming slf4j convention. use `warn(Throwable t, String message, Object... formatArgs)` instead
+   * @param message The string message
+   * @param t The Throwable to log
+   */
+  @Deprecated
+  public void warn(String message, Throwable t) {
+    log.warn(message, t);
+  }
+
   public void warn(String message, Object... formatArgs)
   {
     log.warn(StringUtils.safeFormat(message, formatArgs));
@@ -90,6 +100,16 @@ public class Logger
   public void error(String message, Object... formatArgs)
   {
     log.error(StringUtils.safeFormat(message, formatArgs));
+  }
+
+  /**
+   * Protect against assuming slf4j convention. use `error(Throwable t, String message, Object... formatArgs)` instead
+   * @param message The string message
+   * @param t The Throwable to log
+   */
+  @Deprecated
+  public void error(String message, Throwable t) {
+    log.error(message, t);
   }
 
   public void error(Throwable t, String message, Object... formatArgs)

--- a/src/test/java/com/metamx/common/logger/LoggerTest.java
+++ b/src/test/java/com/metamx/common/logger/LoggerTest.java
@@ -26,4 +26,14 @@ public class LoggerTest
     final Logger log = new Logger(LoggerTest.class);
     log.warn(message);
   }
+
+  @Test
+  public void testLegacyLogging()
+  {
+    final Logger log = new Logger(LoggerTest.class);
+    final Throwable throwable = new Throwable();
+    // These should show up in an IDE as deprecated, but shouldn't actually fail.
+    log.error("foo", throwable);
+    log.warn("foo", throwable);
+  }
 }


### PR DESCRIPTION
It is very easy for people unfamiliar with the logging conventions used here to swap these arguments, sometimes not yielding the desired information. This PR shows that methodology as deprecated and hopefully helps track down erroneous logging usages.

This might potentially change logging if someone had done the following:

`LOG.error("found an error: %s", someException);`

The fix would be to do something like

`LOG.error("found an error: %s", someException.getMessage());`