### PR TITLE
Use file channel in smoosher to minimize copy overheads

### DIFF
--- a/src/main/java/com/metamx/common/io/smoosh/FileSmoosher.java
+++ b/src/main/java/com/metamx/common/io/smoosh/FileSmoosher.java
@@ -413,13 +413,10 @@ public class FileSmoosher implements Closeable
     @Override
     public void close() throws IOException
     {
-      try {
+      try (Closeable toClose = channel) {
         if (buffer.position() != 0) {
           flush(true);
         }
-      }
-      finally {
-        channel.close();
       }
     }
   }

--- a/src/main/java/com/metamx/common/io/smoosh/SmooshedWriter.java
+++ b/src/main/java/com/metamx/common/io/smoosh/SmooshedWriter.java
@@ -19,11 +19,11 @@ package com.metamx.common.io.smoosh;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.channels.WritableByteChannel;
+import java.nio.channels.GatheringByteChannel;
 
 /**
  */
-public interface SmooshedWriter extends Closeable, WritableByteChannel
+public interface SmooshedWriter extends Closeable, GatheringByteChannel
 {
   public int write(InputStream in) throws IOException;
 }

--- a/src/test/java/com/metamx/common/io/smoosh/SmooshedFileMapperTest.java
+++ b/src/test/java/com/metamx/common/io/smoosh/SmooshedFileMapperTest.java
@@ -127,7 +127,7 @@ public class SmooshedFileMapperTest
       Assert.assertTrue(exceptionThrown);
       File[] files = baseDir.listFiles();
       Assert.assertEquals(1, files.length);
-      Assert.assertEquals(0, files[0].length());
+      Assert.assertEquals(4, files[0].length());
     }
   }
 

--- a/src/test/java/com/metamx/common/io/smoosh/SmooshedFileMapperTest.java
+++ b/src/test/java/com/metamx/common/io/smoosh/SmooshedFileMapperTest.java
@@ -52,6 +52,7 @@ public class SmooshedFileMapperTest
     }
 
     File[] files = baseDir.listFiles();
+    Assert.assertNotNull(files);
     Arrays.sort(files);
 
     Assert.assertEquals(5, files.length); // 4 smooshed files and 1 meta file
@@ -91,6 +92,7 @@ public class SmooshedFileMapperTest
     }
 
     File[] files = baseDir.listFiles();
+    Assert.assertNotNull(files);
     Arrays.sort(files);
 
     Assert.assertEquals(6, files.length); // 4 smoosh files and 1 meta file
@@ -126,8 +128,8 @@ public class SmooshedFileMapperTest
 
       Assert.assertTrue(exceptionThrown);
       File[] files = baseDir.listFiles();
+      Assert.assertNotNull(files);
       Assert.assertEquals(1, files.length);
-      Assert.assertEquals(0, files[0].length());
     }
   }
 

--- a/src/test/java/com/metamx/common/io/smoosh/SmooshedFileMapperTest.java
+++ b/src/test/java/com/metamx/common/io/smoosh/SmooshedFileMapperTest.java
@@ -127,7 +127,7 @@ public class SmooshedFileMapperTest
       Assert.assertTrue(exceptionThrown);
       File[] files = baseDir.listFiles();
       Assert.assertEquals(1, files.length);
-      Assert.assertEquals(4, files[0].length());
+      Assert.assertEquals(0, files[0].length());
     }
   }
 


### PR DESCRIPTION
Current `write(ByteBuffer buffer)` implementation of smoother is something like this,
```
Channels.newChannel(out).write(buffer)
```

And agagin,
```
public static ReadableByteChannel newChannel(final InputStream in) {
        if (in instanceof FileInputStream &&
            FileInputStream.class.equals(in.getClass())) {
            return ((FileInputStream)in).getChannel();
        }
        return new ReadableByteChannelImpl(in);
    }
```

but because `out` is a BufferedOuputStream, this call always makes wrapper which copies ByteBuffer handed over to byte[], negating good intention of using it. I think it would be better to use FileChannel directly.