### PR TITLE
ResourceClosingSequence need not to create yielder for simple accumulation

### DIFF
--- a/src/main/java/com/metamx/common/guava/ResourceClosingSequence.java
+++ b/src/main/java/com/metamx/common/guava/ResourceClosingSequence.java
@@ -20,7 +20,7 @@ import java.io.Closeable;
 
 /**
  */
-public class ResourceClosingSequence<T> extends YieldingSequenceBase<T>
+public class ResourceClosingSequence<T> implements Sequence<T>
 {
   private final Sequence<T> baseSequence;
   private final Closeable closeable;
@@ -29,6 +29,17 @@ public class ResourceClosingSequence<T> extends YieldingSequenceBase<T>
   {
     this.baseSequence = baseSequence;
     this.closeable = closeable;
+  }
+
+  @Override
+  public <OutType> OutType accumulate(OutType initValue, Accumulator<OutType, T> accumulator)
+  {
+    try {
+      return baseSequence.accumulate(initValue, accumulator);
+    }
+    finally {
+      CloseQuietly.close(closeable);
+    }
   }
 
   @Override


### PR DESCRIPTION
ResourceClosingSequence makes yielder for simple accumulation, which is not necessary. 

before,
```
        at io.druid.query.QueryRunnerHelper$1.apply(QueryRunnerHelper.java:77)
        at com.metamx.common.guava.MappingYieldingAccumulator.accumulate(MappingYieldingAccumulator.java:57)
        at com.metamx.common.guava.FilteringYieldingAccumulator.accumulate(FilteringYieldingAccumulator.java:69)
        at com.metamx.common.guava.MappingYieldingAccumulator.accumulate(MappingYieldingAccumulator.java:57)
        at com.metamx.common.guava.BaseSequence.makeYielder(BaseSequence.java:104)
        at com.metamx.common.guava.BaseSequence.toYielder(BaseSequence.java:81)
        at com.metamx.common.guava.MappedSequence.toYielder(MappedSequence.java:46)
        at com.metamx.common.guava.ResourceClosingSequence.toYielder(ResourceClosingSequence.java:41)
        at com.metamx.common.guava.FilteredSequence.toYielder(FilteredSequence.java:52)
        at com.metamx.common.guava.MappedSequence.toYielder(MappedSequence.java:46)
        at com.metamx.common.guava.FilteredSequence.toYielder(FilteredSequence.java:52)
        at com.metamx.common.guava.ResourceClosingSequence.toYielder(ResourceClosingSequence.java:41)
        at com.metamx.common.guava.YieldingSequenceBase.accumulate(YieldingSequenceBase.java:34)
        at io.druid.query.MetricsEmittingQueryRunner$1.accumulate(MetricsEmittingQueryRunner.java:118)
        at io.druid.query.MetricsEmittingQueryRunner$1.accumulate(MetricsEmittingQueryRunner.java:118)
        at io.druid.query.spec.SpecificSegmentQueryRunner$2$1.call(SpecificSegmentQueryRunner.java:87)
```

after

```
        at com.metamx.common.guava.MappingAccumulator.accumulate(MappingAccumulator.java:39)
        at com.metamx.common.guava.FilteringAccumulator.accumulate(FilteringAccumulator.java:40)
        at com.metamx.common.guava.MappingAccumulator.accumulate(MappingAccumulator.java:39)
        at com.metamx.common.guava.YieldingAccumulators$1.accumulate(YieldingAccumulators.java:32)
        at com.metamx.common.guava.BaseSequence.makeYielder(BaseSequence.java:104)
        at com.metamx.common.guava.BaseSequence.toYielder(BaseSequence.java:81)
        at com.metamx.common.guava.BaseSequence.accumulate(BaseSequence.java:67)
        at com.metamx.common.guava.MappedSequence.accumulate(MappedSequence.java:40)
        at com.metamx.common.guava.ResourceClosingSequence.accumulate(ResourceClosingSequence.java:38)
        at com.metamx.common.guava.FilteredSequence.accumulate(FilteredSequence.java:42)
        at com.metamx.common.guava.MappedSequence.accumulate(MappedSequence.java:40)
        at com.metamx.common.guava.FilteredSequence.accumulate(FilteredSequence.java:42)
        at com.metamx.common.guava.ResourceClosingSequence.accumulate(ResourceClosingSequence.java:38)
        at io.druid.query.MetricsEmittingQueryRunner$1.accumulate(MetricsEmittingQueryRunner.java:118)
        at io.druid.query.MetricsEmittingQueryRunner$1.accumulate(MetricsEmittingQueryRunner.java:118)
        at io.druid.query.spec.SpecificSegmentQueryRunner$2$1.call(SpecificSegmentQueryRunner.java:87)
```

Because some yielders make new yielder for each next() call, the later looks more efficient.