### PR TITLE
File smoosher changes

### DIFF
--- a/src/main/java/com/metamx/common/io/smoosh/FileSmoosher.java
+++ b/src/main/java/com/metamx/common/io/smoosh/FileSmoosher.java
@@ -74,7 +74,7 @@ public class FileSmoosher implements Closeable
 
   public FileSmoosher(
       File baseDir
-      )
+  )
   {
     this(baseDir, Integer.MAX_VALUE);
   }
@@ -82,7 +82,7 @@ public class FileSmoosher implements Closeable
   public FileSmoosher(
       File baseDir,
       int maxChunkSize
-      )
+  )
   {
     this.baseDir = baseDir;
     this.maxChunkSize = maxChunkSize;
@@ -206,7 +206,6 @@ public class FileSmoosher implements Closeable
               String.format("Expected [%,d] bytes, only saw [%,d], potential corruption?", size, bytesWritten)
           );
         }
-
         mergeWithSmoosher();
       }
     };
@@ -314,8 +313,8 @@ public class FileSmoosher implements Closeable
                 metadata.getFileNum(),
                 metadata.getStartOffset(),
                 metadata.getEndOffset()
-                )
-            );
+            )
+        );
         out.write("\n");
       }
     }

--- a/src/main/java/com/metamx/common/io/smoosh/FileSmoosher.java
+++ b/src/main/java/com/metamx/common/io/smoosh/FileSmoosher.java
@@ -149,7 +149,7 @@ public class FileSmoosher implements Closeable
       throw new IAE("Asked to add buffers[%,d] larger than configured max[%,d]", size, maxChunkSize);
     }
 
-    // if current writer is in use then create a new SmooshedWriter which
+    // If current writer is in use then create a new SmooshedWriter which
     // writes into temporary file which is later merged into original
     // FileSmoosher.
     if (writerCurrentlyInUse)
@@ -231,22 +231,21 @@ public class FileSmoosher implements Closeable
               String.format("Expected [%,d] bytes, only saw [%,d], potential corruption?", size, bytesWritten)
           );
         }
-        // check if delegated smooshedWriter any file, merge with this
-        // FileSmoosher.
+        // Merge temporary files on to the main smoosh file.
         mergeWithSmoosher();
       }
     };
   }
 
   /**
-   * merges temporary files created by delegated SmooshedWriters into original
-   * FileSmoosher.
+   * Merges temporary files created by delegated SmooshedWriters on to the main
+   * smoosh file.
    *
    * @throws IOException
    */
   private void mergeWithSmoosher() throws IOException
   {
-    //get processed elements from the stack and write.
+    // Get processed elements from the stack and write.
     List<File> fileToProcess = new ArrayList<>(completedFiles);
     completedFiles = Lists.newArrayList();
     for (File file: fileToProcess)

--- a/src/main/java/com/metamx/common/io/smoosh/FileSmoosher.java
+++ b/src/main/java/com/metamx/common/io/smoosh/FileSmoosher.java
@@ -138,7 +138,7 @@ public class FileSmoosher implements Closeable
   {
     if(writerCurrentlyInUse)
     {
-      return delegateSmooshedWriter (name , size);
+      return delegateSmooshedWriter(name , size);
     }
 
     if (size > maxChunkSize) {

--- a/src/test/java/com/metamx/common/io/smoosh/SmooshedFileMapperTest.java
+++ b/src/test/java/com/metamx/common/io/smoosh/SmooshedFileMapperTest.java
@@ -58,62 +58,62 @@ public class SmooshedFileMapperTest
   @Test
   public void testWhenFirstWriterClosedInTheMiddle() throws Exception
   {
-	  File baseDir = Files.createTempDir();
+    File baseDir = Files.createTempDir();
 
-	  try (FileSmoosher smoosher = new FileSmoosher(baseDir, 21))
-	  {
-		  final SmooshedWriter writer = smoosher.addWithSmooshedWriter(String.format("%d", 19), 4);
+    try (FileSmoosher smoosher = new FileSmoosher(baseDir, 21))
+    {
+      final SmooshedWriter writer = smoosher.addWithSmooshedWriter(String.format("%d", 19), 4);
 
-		  for (int i = 0; i < 19; ++i) {
-			  File tmpFile = File.createTempFile(String.format("smoosh-%s", i), ".bin");
-			  Files.write(Ints.toByteArray(i), tmpFile);
-			  smoosher.add(String.format("%d", i), tmpFile);
-			  if(i==10)
-			  {
-				  writer.write(ByteBuffer.wrap(Ints.toByteArray(19)));
-				  CloseQuietly.close(writer);
-			  }
-			  tmpFile.delete();
-		  }    
-	  }
-	  validateOutput(baseDir);
+      for (int i = 0; i < 19; ++i) {
+        File tmpFile = File.createTempFile(String.format("smoosh-%s", i), ".bin");
+        Files.write(Ints.toByteArray(i), tmpFile);
+        smoosher.add(String.format("%d", i), tmpFile);
+        if(i==10)
+        {
+          writer.write(ByteBuffer.wrap(Ints.toByteArray(19)));
+          CloseQuietly.close(writer);
+        }
+        tmpFile.delete();
+      }    
+    }
+    validateOutput(baseDir);
   }
-  
+
   @Test(expected= ISE.class)
   public void testExceptionForUnClosedFiles() throws Exception
   {
-	  File baseDir = Files.createTempDir();
+    File baseDir = Files.createTempDir();
 
-	  try (FileSmoosher smoosher = new FileSmoosher(baseDir, 21))
-	  {
-		  for (int i = 0; i < 19; ++i) {
-			  final SmooshedWriter writer = smoosher.addWithSmooshedWriter(String.format("%d", i), 4);
-			  writer.write(ByteBuffer.wrap(Ints.toByteArray(i)));
-		  }
-		  smoosher.close();
-	  }   
+    try (FileSmoosher smoosher = new FileSmoosher(baseDir, 21))
+    {
+      for (int i = 0; i < 19; ++i) {
+        final SmooshedWriter writer = smoosher.addWithSmooshedWriter(String.format("%d", i), 4);
+        writer.write(ByteBuffer.wrap(Ints.toByteArray(i)));
+      }
+      smoosher.close();
+    }   
   }
 
   @Test
-  public void testWhenFirstWriterClosedInTheLast() throws Exception
+  public void testWhenFirstWriterClosedAtTheEnd() throws Exception
   {
-	  File baseDir = Files.createTempDir();
+    File baseDir = Files.createTempDir();
 
-	  try (FileSmoosher smoosher = new FileSmoosher(baseDir, 21))
-	  {
-		  final SmooshedWriter writer = smoosher.addWithSmooshedWriter(String.format("%d", 19), 4);
-		  writer.write(ByteBuffer.wrap(Ints.toByteArray(19)));
+    try (FileSmoosher smoosher = new FileSmoosher(baseDir, 21))
+    {
+      final SmooshedWriter writer = smoosher.addWithSmooshedWriter(String.format("%d", 19), 4);
+      writer.write(ByteBuffer.wrap(Ints.toByteArray(19)));
 
-		  for (int i = 0; i < 19; ++i) {
-			  File tmpFile = File.createTempFile(String.format("smoosh-%s", i), ".bin");
-			  Files.write(Ints.toByteArray(i), tmpFile);
-			  smoosher.add(String.format("%d", i), tmpFile);
-			  tmpFile.delete();
-		  }
-		  CloseQuietly.close(writer);
-		  smoosher.close();
-	  }
-	  validateOutput(baseDir);    
+      for (int i = 0; i < 19; ++i) {
+        File tmpFile = File.createTempFile(String.format("smoosh-%s", i), ".bin");
+        Files.write(Ints.toByteArray(i), tmpFile);
+        smoosher.add(String.format("%d", i), tmpFile);
+        tmpFile.delete();
+      }
+      CloseQuietly.close(writer);
+      smoosher.close();
+    }
+    validateOutput(baseDir);    
   }
 
   @Test
@@ -193,26 +193,26 @@ public class SmooshedFileMapperTest
     // Assert no hanging file mappings left by either smoosher or smoosher.add(file)
     Assert.assertEquals(totalMemoryUsedBeforeAddingFile, totalMemoryUsedAfterAddingFile);
   }
-  
+
   private void validateOutput(File baseDir) throws IOException
   {
-	  File[] files = baseDir.listFiles();
-	  Arrays.sort(files);
+    File[] files = baseDir.listFiles();
+    Arrays.sort(files);
 
-	  Assert.assertEquals(5, files.length); // 4 smooshed files and 1 meta file
-	  for (int i = 0; i < 4; ++i) {
-		  Assert.assertEquals(FileSmoosher.makeChunkFile(baseDir, i), files[i]);
-	  }
-	  Assert.assertEquals(FileSmoosher.metaFile(baseDir), files[files.length - 1]);
+    Assert.assertEquals(5, files.length); // 4 smooshed files and 1 meta file
+    for (int i = 0; i < 4; ++i) {
+      Assert.assertEquals(FileSmoosher.makeChunkFile(baseDir, i), files[i]);
+    }
+    Assert.assertEquals(FileSmoosher.metaFile(baseDir), files[files.length - 1]);
 
-	  try (SmooshedFileMapper mapper = SmooshedFileMapper.load(baseDir)) {
-		  for (int i = 0; i < 20; ++i) {
-			  ByteBuffer buf = mapper.mapFile(String.format("%d", i));
-			  Assert.assertEquals(0, buf.position());
-			  Assert.assertEquals(4, buf.remaining());
-			  Assert.assertEquals(4, buf.capacity());
-			  Assert.assertEquals(i, buf.getInt());
-		  }
-	  }
+    try (SmooshedFileMapper mapper = SmooshedFileMapper.load(baseDir)) {
+      for (int i = 0; i < 20; ++i) {
+        ByteBuffer buf = mapper.mapFile(String.format("%d", i));
+        Assert.assertEquals(0, buf.position());
+        Assert.assertEquals(4, buf.remaining());
+        Assert.assertEquals(4, buf.capacity());
+        Assert.assertEquals(i, buf.getInt());
+      }
+    }
   }
 }

--- a/src/test/java/com/metamx/common/io/smoosh/SmooshedFileMapperTest.java
+++ b/src/test/java/com/metamx/common/io/smoosh/SmooshedFileMapperTest.java
@@ -68,7 +68,7 @@ public class SmooshedFileMapperTest
         File tmpFile = File.createTempFile(String.format("smoosh-%s", i), ".bin");
         Files.write(Ints.toByteArray(i), tmpFile);
         smoosher.add(String.format("%d", i), tmpFile);
-        if(i==10)
+        if (i==10)
         {
           writer.write(ByteBuffer.wrap(Ints.toByteArray(19)));
           CloseQuietly.close(writer);


### PR DESCRIPTION
This pr is to support `FileSmoosher` changes proposed in https://github.com/druid-io/druid/issues/3513 .

`FileSmoosher` detect when it already has an OutputStream open and redirect newly opened OutputStreams to new files on the file system. When any of the open OutputStream objects are closed, they will also check to see if any of the other files have been closed in the meantime. If there are OutputStreams that have been closed, they will be copied on to the main smoosh file and the extra underlying file will be cleaned up. This has the downside of introducing an extra copy to these files, but it given that the strategy will only be used when absolutely necessary, this shouldn’t result in any noticeable performance degradation during indexing.
