### PR TITLE
Resolve most HuntBugs warnings (including two bugs fixed)

### DIFF
--- a/src/main/java/com/metamx/common/CompressionUtils.java
+++ b/src/main/java/com/metamx/common/CompressionUtils.java
@@ -148,7 +148,7 @@ public class CompressionUtils
     } else {
       final File tmpFile = File.createTempFile("compressionUtilZipCache", ZIP_SUFFIX);
       try {
-        FileUtils.FileCopyResult copyResult = FileUtils.retryCopy(
+        FileUtils.retryCopy(
             byteSource,
             tmpFile,
             shouldRetry,

--- a/src/main/java/com/metamx/common/Granularity.java
+++ b/src/main/java/com/metamx/common/Granularity.java
@@ -450,9 +450,6 @@ public enum Granularity
       },
   WEEK
       {
-        DateTimeFormatter defaultFormat = DateTimeFormat.forPattern("'y'=yyyy/'m'=MM/'d'=dd");
-        DateTimeFormatter hiveFormat = DateTimeFormat.forPattern("'dt'=yyyy-MM-dd");
-        DateTimeFormatter lowerDefaultFormat = DateTimeFormat.forPattern("'y'=yyyy/'m'=MM/'d'=dd");
 
         @Override
         public DateTimeFormatter getFormatter(Formatter type)

--- a/src/main/java/com/metamx/common/RetryUtils.java
+++ b/src/main/java/com/metamx/common/RetryUtils.java
@@ -23,6 +23,7 @@ import com.metamx.common.logger.Logger;
 
 import java.util.Random;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class RetryUtils
 {
@@ -82,7 +83,7 @@ public class RetryUtils
   {
     final long baseSleepMillis = 1000;
     final long maxSleepMillis = 60000;
-    final double fuzzyMultiplier = Math.min(Math.max(1 + 0.2 * new Random().nextGaussian(), 0), 2);
+    final double fuzzyMultiplier = Math.min(Math.max(1 + 0.2 * ThreadLocalRandom.current().nextGaussian(), 0), 2);
     final long sleepMillis = (long) (Math.min(maxSleepMillis, baseSleepMillis * Math.pow(2, nTry - 1))
                                      * fuzzyMultiplier);
     if (quiet) {

--- a/src/main/java/com/metamx/common/RetryUtils.java
+++ b/src/main/java/com/metamx/common/RetryUtils.java
@@ -21,7 +21,6 @@ import com.google.common.base.Predicate;
 import com.google.common.base.Throwables;
 import com.metamx.common.logger.Logger;
 
-import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ThreadLocalRandom;
 

--- a/src/main/java/com/metamx/common/StreamUtils.java
+++ b/src/main/java/com/metamx/common/StreamUtils.java
@@ -132,9 +132,9 @@ public class StreamUtils
   public static long copyWithTimeout(InputStream is, OutputStream os, long timeout) throws IOException, TimeoutException
   {
     byte[] buffer = new byte[DEFAULT_BUFFER_SIZE];
-    int n = 0;
+    int n;
     long startTime = System.currentTimeMillis();
-    long size = 0l;
+    long size = 0;
     while (-1 != (n = is.read(buffer))) {
       if (System.currentTimeMillis() - startTime > timeout) {
         throw new TimeoutException(String.format("Copy time has exceeded %,d millis", timeout));

--- a/src/main/java/com/metamx/common/StringUtils.java
+++ b/src/main/java/com/metamx/common/StringUtils.java
@@ -29,7 +29,6 @@ import java.util.IllegalFormatException;
  */
 public class StringUtils
 {
-  private static final Logger log = new Logger(StringUtils.class);
   @Deprecated // Charset parameters to String are currently slower than the charset's string name
   public static final Charset UTF8_CHARSET = Charsets.UTF_8;
   public static final String UTF8_STRING = com.google.common.base.Charsets.UTF_8.toString();

--- a/src/main/java/com/metamx/common/guava/Comparators.java
+++ b/src/main/java/com/metamx/common/guava/Comparators.java
@@ -40,7 +40,7 @@ public class Comparators
       @Override
       public int compare(T t, T t1)
       {
-        return - baseComp.compare(t, t1);
+        return baseComp.compare(t1, t);
       }
     };
   }

--- a/src/main/java/com/metamx/common/guava/LimitedYieldingAccumulator.java
+++ b/src/main/java/com/metamx/common/guava/LimitedYieldingAccumulator.java
@@ -18,6 +18,7 @@ package com.metamx.common.guava;
 
 /**
  */
+@Deprecated
 public class LimitedYieldingAccumulator<OutType, T> extends YieldingAccumulator<OutType, T>
 {
   private final int limit;

--- a/src/main/java/com/metamx/common/guava/LimitedYieldingAccumulator.java
+++ b/src/main/java/com/metamx/common/guava/LimitedYieldingAccumulator.java
@@ -17,6 +17,8 @@
 package com.metamx.common.guava;
 
 /**
+ * @deprecated this class uses expensive volatile counter inside, but it is not thread-safe. It is going to be removed
+ * in the future.
  */
 @Deprecated
 public class LimitedYieldingAccumulator<OutType, T> extends YieldingAccumulator<OutType, T>

--- a/src/main/java/com/metamx/common/parsers/CSVParser.java
+++ b/src/main/java/com/metamx/common/parsers/CSVParser.java
@@ -31,7 +31,6 @@ import java.util.Map;
 
 public class CSVParser implements Parser<String, Object>
 {
-  private static final Logger log = new Logger(CSVParser.class);
 
   private final String listDelimiter;
   private final Splitter listSplitter;

--- a/src/main/java/com/metamx/common/parsers/DelimitedParser.java
+++ b/src/main/java/com/metamx/common/parsers/DelimitedParser.java
@@ -33,7 +33,6 @@ import java.util.Map;
 
 public class DelimitedParser implements Parser<String, Object>
 {
-  private static final Logger log = new Logger(DelimitedParser.class);
   private static final String DEFAULT_DELIMITER = "\t";
 
   private final String delimiter;

--- a/src/main/java/com/metamx/common/parsers/JSONPathParser.java
+++ b/src/main/java/com/metamx/common/parsers/JSONPathParser.java
@@ -44,7 +44,6 @@ import java.util.Map;
 public class JSONPathParser implements Parser<String, Object>
 {
   private final Map<String, Pair<FieldType, JsonPath>> fieldPathMap;
-  private final List<FieldSpec> fieldSpecs;
   private final boolean useFieldDiscovery;
   private final ObjectMapper mapper;
   private final CharsetEncoder enc = Charsets.UTF_8.newEncoder();
@@ -60,7 +59,6 @@ public class JSONPathParser implements Parser<String, Object>
    */
   public JSONPathParser(List<FieldSpec> fieldSpecs, boolean useFieldDiscovery, ObjectMapper mapper)
   {
-    this.fieldSpecs = fieldSpecs;
     this.fieldPathMap = generateFieldPaths(fieldSpecs);
     this.useFieldDiscovery = useFieldDiscovery;
     this.mapper = mapper == null ? new ObjectMapper() : mapper;
@@ -145,9 +143,10 @@ public class JSONPathParser implements Parser<String, Object>
 
   private void discoverFields(Map<String, Object> map, Map<String, Object> document)
   {
-    for (String field : document.keySet()) {
+    for (Map.Entry<String, Object> e : document.entrySet()) {
+      String field = e.getKey();
       if (!map.containsKey(field)) {
-        Object val = document.get(field);
+        Object val = e.getValue();
         if (val == null) {
           continue;
         }

--- a/src/main/java/com/metamx/common/parsers/TimestampParser.java
+++ b/src/main/java/com/metamx/common/parsers/TimestampParser.java
@@ -26,7 +26,6 @@ import org.joda.time.format.DateTimeFormatter;
 
 public class TimestampParser
 {
-  private static final Logger log = new Logger(TimestampParser.class);
 
   public static Function<String, DateTime> createTimestampParser(
       final String format

--- a/src/test/java/com/metamx/common/guava/ComparatorsTest.java
+++ b/src/test/java/com/metamx/common/guava/ComparatorsTest.java
@@ -42,6 +42,20 @@ public class ComparatorsTest
   }
 
   @Test
+  public void testInverseOverflow()
+  {
+    Comparator<Integer> invertedSimpleIntegerComparator = Comparators.inverse(new Comparator<Integer>()
+    {
+      @Override
+      public int compare(Integer o1, Integer o2)
+      {
+        return o1 - o2;
+      }
+    });
+    Assert.assertTrue(invertedSimpleIntegerComparator.compare(0, Integer.MIN_VALUE) < 0);
+  }
+
+  @Test
   public void testIntervalsByStartThenEnd() throws Exception
   {
     Comparator<Interval> comp = Comparators.intervalsByStartThenEnd();


### PR DESCRIPTION
 - bug fix 1: https://github.com/metamx/java-util/pull/56/files#diff-aba6de6f4670f473afd1ae9ba6ef209bR86 (don't allocate `new Random()` each time we need a random value).
 - bug fix 2: https://github.com/metamx/java-util/pull/56/files#diff-be255ea78e884c6ed2e259dfd9528b94R43, Comparators.inverse() is broken if the source comparator returns `Integer.MIN_VALUE`.