### PR TITLE
Update async-http-client version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
         <dependency>
             <groupId>org.asynchttpclient</groupId>
             <artifactId>async-http-client</artifactId>
-            <version>2.0.37</version>
+            <version>2.9.0</version>
         </dependency>
 
         <!-- Extra dependencies for server-metrics -->


### PR DESCRIPTION
Scala-util depends on java-util and requires netty 4.1.x (finagle is bringing it). But old async-http-client had 4.0.x, which is not compatible.