### PR TITLE
Black and white list based event filter for parametrized emitter

### DIFF
--- a/src/main/java/com/metamx/emitter/core/JacksonUtil.java
+++ b/src/main/java/com/metamx/emitter/core/JacksonUtil.java
@@ -1,0 +1,31 @@
+package com.metamx.emitter.core;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class JacksonUtil
+{
+  public static class CommaDelimitedListDeserializer extends StdScalarDeserializer<List<String>>
+  {
+    protected CommaDelimitedListDeserializer()
+    {
+      super(List.class);
+    }
+
+    @Override
+    public List<String> deserialize(
+        JsonParser jsonParser,
+        DeserializationContext deserializationContext
+    ) throws IOException
+    {
+      final String text = jsonParser.getText().trim();
+      return Arrays.stream(text.split(",")).map(String::trim).collect(Collectors.toList());
+    }
+  }
+}

--- a/src/main/java/com/metamx/emitter/core/ParametrizedUriEmitterConfig.java
+++ b/src/main/java/com/metamx/emitter/core/ParametrizedUriEmitterConfig.java
@@ -1,12 +1,15 @@
 package com.metamx.emitter.core;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.metamx.emitter.core.filter.BWListEventFilterConfig;
 
 import javax.validation.constraints.NotNull;
 
 public class ParametrizedUriEmitterConfig
 {
   private static final BaseHttpEmittingConfig DEFAULT_HTTP_EMITTING_CONFIG = new BaseHttpEmittingConfig();
+
+  private static final BWListEventFilterConfig DEFAULT_BW_LIST_EVENT_FILTER_CONFIG = new BWListEventFilterConfig();
 
   @NotNull
   @JsonProperty
@@ -15,9 +18,17 @@ public class ParametrizedUriEmitterConfig
   @JsonProperty("httpEmitting")
   private BaseHttpEmittingConfig httpEmittingConfig = DEFAULT_HTTP_EMITTING_CONFIG;
 
+  @JsonProperty("bwFilter")
+  private BWListEventFilterConfig bwListEventFilterConfig = DEFAULT_BW_LIST_EVENT_FILTER_CONFIG;
+
   public String getRecipientBaseUrlPattern()
   {
     return recipientBaseUrlPattern;
+  }
+
+  public BWListEventFilterConfig getBwListEventFilterConfig()
+  {
+    return bwListEventFilterConfig;
   }
 
   public HttpEmitterConfig buildHttpEmitterConfig(String baseUri)
@@ -30,7 +41,8 @@ public class ParametrizedUriEmitterConfig
   {
     return "ParametrizedUriEmitterConfig{" +
            "recipientBaseUrlPattern='" + recipientBaseUrlPattern + '\'' +
-           ", httpEmittingConfig=" + httpEmittingConfig +
+           ", httpEmittingConfig=" + httpEmittingConfig + '\'' +
+           ", bwListEventFilterConfig='" + bwListEventFilterConfig +
            '}';
   }
 }

--- a/src/main/java/com/metamx/emitter/core/filter/BWListEventFilter.java
+++ b/src/main/java/com/metamx/emitter/core/filter/BWListEventFilter.java
@@ -1,0 +1,33 @@
+package com.metamx.emitter.core.filter;
+
+import com.metamx.emitter.core.Event;
+
+/**
+ * Filters out events based on white and black lists of event field values.
+ */
+public interface BWListEventFilter
+{
+  /**
+   * Checks if an event is not whitelisted.
+   * There are three possible cases: whitelisted, not whitelisted, the white list is not defined.
+   * "Is not whitelisted" is opposite to the other two options so it's used as a predicate to decide
+   * if the event should be filtered out.
+   */
+  boolean isNotWhiteListed(Event event);
+
+  /**
+   * Checks if an event is blacklisted.
+   * There are three possible cases: blacklisted, not blacklisted, the black list is not defined.
+   * "Is blacklisted" is opposite to the other two options so it's used as a predicate to decide
+   * if the event should be filtered out.
+   */
+  boolean isBlackListed(Event event);
+
+  /**
+   * Checks if an event is not whitelisted or is blacklisted.
+   */
+  default boolean isNotListed(Event event)
+  {
+    return isNotWhiteListed(event) || isBlackListed(event);
+  }
+}

--- a/src/main/java/com/metamx/emitter/core/filter/BWListEventFilterConfig.java
+++ b/src/main/java/com/metamx/emitter/core/filter/BWListEventFilterConfig.java
@@ -1,0 +1,43 @@
+package com.metamx.emitter.core.filter;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.collect.ImmutableMap;
+import com.metamx.emitter.core.JacksonUtil;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A config for {@link BWListEventFilter}.
+ */
+public class BWListEventFilterConfig
+{
+  @JsonProperty
+  @JsonDeserialize(contentUsing = JacksonUtil.CommaDelimitedListDeserializer.class)
+  private Map<String, List<String>> whiteList = ImmutableMap.of();
+
+  @JsonProperty
+  @JsonDeserialize(contentUsing = JacksonUtil.CommaDelimitedListDeserializer.class)
+  private Map<String, List<String>> blackList = ImmutableMap.of();
+
+  public Map<String, List<String>> getWhiteList()
+  {
+    return whiteList;
+  }
+
+  public Map<String, List<String>> getBlackList()
+  {
+    return blackList;
+  }
+
+  @Override
+  public String toString()
+  {
+    return "BWListEventFilterConfig{" +
+           "whiteList='" + whiteList + '\'' +
+           ", blackList='" + blackList + '\'' +
+           '}';
+  }
+
+}

--- a/src/main/java/com/metamx/emitter/core/filter/BWListEventFilterFactory.java
+++ b/src/main/java/com/metamx/emitter/core/filter/BWListEventFilterFactory.java
@@ -1,0 +1,29 @@
+package com.metamx.emitter.core.filter;
+
+import java.util.HashSet;
+
+/**
+ * The factory creates {@link BWListEventFilter} out of the {@link BWListEventFilterConfig}.
+ */
+public class BWListEventFilterFactory
+{
+  private static final String FEED_FIELD_NAME = "feed";
+
+  public static BWListEventFilter makeEventFilter(BWListEventFilterConfig config)
+  {
+    final HashSet<String> commonKeys = new HashSet<>(config.getWhiteList().keySet());
+    commonKeys.addAll(config.getBlackList().keySet());
+    if (commonKeys.size() == 0) {
+      return new EmptyBWListEventFilter();
+    }
+    if (commonKeys.size() == 1 && commonKeys.contains(FEED_FIELD_NAME)) {
+      return new FeedBWListEventFilter(
+          config.getWhiteList().get(FEED_FIELD_NAME),
+          config.getBlackList().get(FEED_FIELD_NAME)
+      );
+    } else {
+      return new MultiBWListEventFilter(config.getWhiteList(), config.getBlackList());
+    }
+  }
+
+}

--- a/src/main/java/com/metamx/emitter/core/filter/EmptyBWListEventFilter.java
+++ b/src/main/java/com/metamx/emitter/core/filter/EmptyBWListEventFilter.java
@@ -1,0 +1,21 @@
+package com.metamx.emitter.core.filter;
+
+import com.metamx.emitter.core.Event;
+
+/**
+ * The {@link BWListEventFilter} with no white and black lists.
+ */
+public class EmptyBWListEventFilter implements BWListEventFilter
+{
+  @Override
+  public boolean isNotWhiteListed(Event event)
+  {
+    return false;
+  }
+
+  @Override
+  public boolean isBlackListed(Event event)
+  {
+    return false;
+  }
+}

--- a/src/main/java/com/metamx/emitter/core/filter/FeedBWListEventFilter.java
+++ b/src/main/java/com/metamx/emitter/core/filter/FeedBWListEventFilter.java
@@ -1,0 +1,35 @@
+package com.metamx.emitter.core.filter;
+
+import com.metamx.emitter.core.Event;
+
+import javax.annotation.Nullable;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * The {@link BWListEventFilter} that has only BW lists for a {@link Event}'s feed field.
+ */
+public class FeedBWListEventFilter implements BWListEventFilter
+{
+  private final Set<String> whiteSet;
+  private final Set<String> blackSet;
+
+  public FeedBWListEventFilter(@Nullable List<String> whiteList, @Nullable List<String> blackList)
+  {
+    this.whiteSet = whiteList == null ? null : new HashSet<>(whiteList);
+    this.blackSet = blackList == null ? null : new HashSet<>(blackList);
+  }
+
+  @Override
+  public boolean isNotWhiteListed(Event event)
+  {
+    return !(whiteSet == null || whiteSet.contains(event.getFeed()));
+  }
+
+  @Override
+  public boolean isBlackListed(Event event)
+  {
+    return blackSet != null && blackSet.contains(event.getFeed());
+  }
+}

--- a/src/main/java/com/metamx/emitter/core/filter/MultiBWListEventFilter.java
+++ b/src/main/java/com/metamx/emitter/core/filter/MultiBWListEventFilter.java
@@ -1,0 +1,52 @@
+package com.metamx.emitter.core.filter;
+
+import com.metamx.emitter.core.Event;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * The {@link BWListEventFilter} that supports BW lists for any field.
+ * Before checking an event the filter converts the event to a map and iterates over the map keys.
+ */
+public class MultiBWListEventFilter implements BWListEventFilter
+{
+  private final Map<String, Set<String>> fieldToValueWhiteSet;
+  private final Map<String, Set<String>> fieldToValueBlackSet;
+
+  public MultiBWListEventFilter(
+      Map<String, List<String>> fieldToValueWhiteList,
+      Map<String, List<String>> fieldToValueBlackList
+  )
+  {
+    this.fieldToValueWhiteSet = fieldToValueWhiteList.entrySet().stream().collect(Collectors.toMap(
+        Map.Entry::getKey,
+        e -> new HashSet<>(e.getValue())
+    ));
+    this.fieldToValueBlackSet = fieldToValueBlackList.entrySet().stream().collect(Collectors.toMap(
+        Map.Entry::getKey,
+        e -> new HashSet<>(e.getValue())
+    ));
+  }
+
+  @Override
+  public boolean isNotWhiteListed(Event event)
+  {
+    final Map<String, Object> eventMap = event.toMap();
+    return fieldToValueWhiteSet.entrySet().stream().anyMatch(
+        e -> eventMap.containsKey(e.getKey()) && !e.getValue().contains(eventMap.get(e.getKey()))
+    );
+  }
+
+  @Override
+  public boolean isBlackListed(Event event)
+  {
+    final Map<String, Object> eventMap = event.toMap();
+    return fieldToValueBlackSet.entrySet().stream().anyMatch(
+        e -> eventMap.containsKey(e.getKey()) && e.getValue().contains(eventMap.get(e.getKey()))
+    );
+  }
+}

--- a/src/test/java/com/metamx/emitter/core/BWListEventFilterConfigTest.java
+++ b/src/test/java/com/metamx/emitter/core/BWListEventFilterConfigTest.java
@@ -1,0 +1,46 @@
+package com.metamx.emitter.core;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.metamx.emitter.core.Emitters;
+import com.metamx.emitter.core.ParametrizedUriEmitterConfig;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Properties;
+
+public class BWListEventFilterConfigTest
+{
+  @Test
+  public void testDefaults()
+  {
+    final Properties props = new Properties();
+
+    final ObjectMapper objectMapper = new ObjectMapper();
+    final ParametrizedUriEmitterConfig paramConfig = objectMapper.convertValue(Emitters.makeCustomFactoryMap(props), ParametrizedUriEmitterConfig.class);
+
+    Assert.assertTrue(paramConfig.getBwListEventFilterConfig().getWhiteList().isEmpty());
+    Assert.assertTrue(paramConfig.getBwListEventFilterConfig().getBlackList().isEmpty());
+  }
+
+  @Test
+  public void testSettingEverything()
+  {
+    final Properties props = new Properties();
+    props.setProperty("com.metamx.emitter.bwFilter.whiteList.A", "AW1, AW2");
+    props.setProperty("com.metamx.emitter.bwFilter.blackList.A", "AB1, AB2");
+    props.setProperty("com.metamx.emitter.bwFilter.blackList.B", "BB1, BB2");
+
+    final ObjectMapper objectMapper = new ObjectMapper();
+    final ParametrizedUriEmitterConfig paramConfig = objectMapper.convertValue(Emitters.makeCustomFactoryMap(props), ParametrizedUriEmitterConfig.class);
+
+    Assert.assertTrue(paramConfig.getBwListEventFilterConfig().getWhiteList().containsKey("A"));
+    Assert.assertTrue(paramConfig.getBwListEventFilterConfig().getWhiteList().get("A").contains("AW1"));
+    Assert.assertTrue(paramConfig.getBwListEventFilterConfig().getWhiteList().get("A").contains("AW2"));
+    Assert.assertTrue(paramConfig.getBwListEventFilterConfig().getBlackList().containsKey("A"));
+    Assert.assertTrue(paramConfig.getBwListEventFilterConfig().getBlackList().get("A").contains("AB1"));
+    Assert.assertTrue(paramConfig.getBwListEventFilterConfig().getBlackList().get("A").contains("AB2"));
+    Assert.assertTrue(paramConfig.getBwListEventFilterConfig().getBlackList().containsKey("B"));
+    Assert.assertTrue(paramConfig.getBwListEventFilterConfig().getBlackList().get("B").contains("BB1"));
+    Assert.assertTrue(paramConfig.getBwListEventFilterConfig().getBlackList().get("B").contains("BB2"));
+  }
+}

--- a/src/test/java/com/metamx/emitter/core/EmittersTest.java
+++ b/src/test/java/com/metamx/emitter/core/EmittersTest.java
@@ -1,0 +1,21 @@
+package com.metamx.emitter.core;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.Properties;
+
+public class EmittersTest
+{
+  @Test
+  public void makeCustomFactoryMapTest()
+  {
+    final Properties properties = new Properties();
+    properties.setProperty("com.metamx.emitter.property.A", "valueA");
+    properties.setProperty("com.metamx.emitter.property.B", "valueB");
+    final Map<String, Object> map = Emitters.makeCustomFactoryMap(properties);
+    Assert.assertEquals("valueA", ((Map<?, ?>) map.get("property")).get("A"));
+    Assert.assertEquals("valueB", ((Map<?, ?>) map.get("property")).get("B"));
+  }
+}

--- a/src/test/java/com/metamx/emitter/core/MapEvent.java
+++ b/src/test/java/com/metamx/emitter/core/MapEvent.java
@@ -1,0 +1,51 @@
+package com.metamx.emitter.core;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.util.StdConverter;
+import org.joda.time.DateTime;
+
+import java.util.Map;
+
+@JsonSerialize(converter = MapEvent.MapEventConverter.class)
+public final class MapEvent implements Event
+{
+  private final Map<String, Object> map;
+
+  public MapEvent(Map<String, Object> map)
+  {
+    this.map = map;
+  }
+
+  @Override
+  public Map<String, Object> toMap()
+  {
+    return map;
+  }
+
+  @Override
+  public String getFeed()
+  {
+    return (String) map.get("feed");
+  }
+
+  @Override
+  public DateTime getCreatedTime()
+  {
+    return (DateTime) map.get("createdTime");
+  }
+
+  @Override
+  public boolean isSafeToBuffer()
+  {
+    return map.containsKey("isSafeToBuffer");
+  }
+
+  public static class MapEventConverter extends StdConverter<MapEvent, Map<String, Object>>
+  {
+    @Override
+    public Map<String, Object> convert(MapEvent value)
+    {
+      return value.toMap();
+    }
+  }
+}

--- a/src/test/java/com/metamx/emitter/core/filter/EmptyBWListEventFilterTest.java
+++ b/src/test/java/com/metamx/emitter/core/filter/EmptyBWListEventFilterTest.java
@@ -1,0 +1,17 @@
+package com.metamx.emitter.core.filter;
+
+import com.google.common.collect.ImmutableMap;
+import com.metamx.emitter.core.MapEvent;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class EmptyBWListEventFilterTest
+{
+  @Test
+  public void isListed()
+  {
+    final EmptyBWListEventFilter eventFilter = new EmptyBWListEventFilter();
+    Assert.assertFalse(eventFilter.isNotListed(new MapEvent(ImmutableMap.of())));
+    Assert.assertFalse(eventFilter.isNotListed(new MapEvent(ImmutableMap.of("A", "A1"))));
+  }
+}

--- a/src/test/java/com/metamx/emitter/core/filter/FeedBWListEventFilterTest.java
+++ b/src/test/java/com/metamx/emitter/core/filter/FeedBWListEventFilterTest.java
@@ -1,0 +1,63 @@
+package com.metamx.emitter.core.filter;
+
+import com.google.common.collect.ImmutableMap;
+import com.metamx.emitter.core.MapEvent;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+public class FeedBWListEventFilterTest
+{
+  @Test
+  public void emptyFeedWhiteListTest()
+  {
+    final FeedBWListEventFilter feedEventSkipFilter = new FeedBWListEventFilter(null, null);
+
+    Assert.assertFalse(feedEventSkipFilter.isNotWhiteListed(new MapEvent(ImmutableMap.of("feed", "F1"))));
+    Assert.assertFalse(feedEventSkipFilter.isNotWhiteListed(new MapEvent(ImmutableMap.of("feed", "F2"))));
+
+    Assert.assertFalse(feedEventSkipFilter.isNotListed(new MapEvent(ImmutableMap.of("feed", "F1"))));
+    Assert.assertFalse(feedEventSkipFilter.isNotListed(new MapEvent(ImmutableMap.of("feed", "F2"))));
+  }
+
+  @Test
+  public void emptyFeedBlackListTest()
+  {
+    final FeedBWListEventFilter feedEventSkipFilter = new FeedBWListEventFilter(null, null);
+
+    Assert.assertFalse(feedEventSkipFilter.isBlackListed(new MapEvent(ImmutableMap.of("feed", "F1"))));
+    Assert.assertFalse(feedEventSkipFilter.isBlackListed(new MapEvent(ImmutableMap.of("feed", "F2"))));
+
+    Assert.assertFalse(feedEventSkipFilter.isNotListed(new MapEvent(ImmutableMap.of("feed", "F1"))));
+    Assert.assertFalse(feedEventSkipFilter.isNotListed(new MapEvent(ImmutableMap.of("feed", "F2"))));
+  }
+
+  @Test
+  public void feedWhiteListTest()
+  {
+    final FeedBWListEventFilter feedEventSkipFilter = new FeedBWListEventFilter(Arrays.asList("F1", "F2"), null);
+
+    Assert.assertFalse(feedEventSkipFilter.isNotWhiteListed(new MapEvent(ImmutableMap.of("feed", "F1"))));
+    Assert.assertFalse(feedEventSkipFilter.isNotWhiteListed(new MapEvent(ImmutableMap.of("feed", "F2"))));
+    Assert.assertTrue(feedEventSkipFilter.isNotWhiteListed(new MapEvent(ImmutableMap.of("feed", "F3"))));
+
+    Assert.assertFalse(feedEventSkipFilter.isNotListed(new MapEvent(ImmutableMap.of("feed", "F1"))));
+    Assert.assertFalse(feedEventSkipFilter.isNotListed(new MapEvent(ImmutableMap.of("feed", "F2"))));
+    Assert.assertTrue(feedEventSkipFilter.isNotListed(new MapEvent(ImmutableMap.of("feed", "F3"))));
+  }
+
+  @Test
+  public void feedBlackListTest()
+  {
+    final FeedBWListEventFilter feedEventSkipFilter = new FeedBWListEventFilter(null, Arrays.asList("F1", "F2"));
+
+    Assert.assertTrue(feedEventSkipFilter.isBlackListed(new MapEvent(ImmutableMap.of("feed", "F1"))));
+    Assert.assertTrue(feedEventSkipFilter.isBlackListed(new MapEvent(ImmutableMap.of("feed", "F2"))));
+    Assert.assertFalse(feedEventSkipFilter.isBlackListed(new MapEvent(ImmutableMap.of("feed", "F3"))));
+
+    Assert.assertTrue(feedEventSkipFilter.isNotListed(new MapEvent(ImmutableMap.of("feed", "F1"))));
+    Assert.assertTrue(feedEventSkipFilter.isNotListed(new MapEvent(ImmutableMap.of("feed", "F2"))));
+    Assert.assertFalse(feedEventSkipFilter.isNotListed(new MapEvent(ImmutableMap.of("feed", "F3"))));
+  }
+}

--- a/src/test/java/com/metamx/emitter/core/filter/MultiBWListEventFilterTest.java
+++ b/src/test/java/com/metamx/emitter/core/filter/MultiBWListEventFilterTest.java
@@ -1,0 +1,93 @@
+package com.metamx.emitter.core.filter;
+
+import com.google.common.collect.ImmutableMap;
+import com.metamx.emitter.core.MapEvent;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+
+public class MultiBWListEventFilterTest
+{
+  @Test
+  public void whiteListTest()
+  {
+    final MultiBWListEventFilter baseEventFilter = new MultiBWListEventFilter(
+        ImmutableMap.of(
+            "A", Collections.singletonList("A1"),
+            "B", Arrays.asList("B1", "B2"),
+            "C", new ArrayList<>()
+        ),
+        ImmutableMap.of()
+    );
+    Assert.assertFalse(baseEventFilter.isNotWhiteListed(new MapEvent(ImmutableMap.of("A", "A1"))));
+    Assert.assertTrue(baseEventFilter.isNotWhiteListed(new MapEvent(ImmutableMap.of("A", "A2"))));
+
+    Assert.assertFalse(baseEventFilter.isNotWhiteListed(new MapEvent(ImmutableMap.of("B", "B1"))));
+    Assert.assertFalse(baseEventFilter.isNotWhiteListed(new MapEvent(ImmutableMap.of("B", "B2"))));
+    Assert.assertTrue(baseEventFilter.isNotWhiteListed(new MapEvent(ImmutableMap.of("B", "B3"))));
+
+    Assert.assertTrue(baseEventFilter.isNotWhiteListed(new MapEvent(ImmutableMap.of("C", "C1"))));
+    Assert.assertTrue(baseEventFilter.isNotWhiteListed(new MapEvent(ImmutableMap.of("C", "C2"))));
+
+    Assert.assertFalse(baseEventFilter.isNotWhiteListed(new MapEvent(ImmutableMap.of("D", "D1"))));
+  }
+
+  @Test
+  public void blackListTest()
+  {
+    final MultiBWListEventFilter baseEventFilter = new MultiBWListEventFilter(
+        ImmutableMap.of(),
+        ImmutableMap.of(
+            "A", Collections.singletonList("A1"),
+            "B", Arrays.asList("B1", "B2"),
+            "C", new ArrayList<>()
+        )
+    );
+    Assert.assertTrue(baseEventFilter.isBlackListed(new MapEvent(ImmutableMap.of("A", "A1"))));
+    Assert.assertFalse(baseEventFilter.isBlackListed(new MapEvent(ImmutableMap.of("A", "A2"))));
+
+    Assert.assertTrue(baseEventFilter.isBlackListed(new MapEvent(ImmutableMap.of("B", "B1"))));
+    Assert.assertTrue(baseEventFilter.isBlackListed(new MapEvent(ImmutableMap.of("B", "B2"))));
+    Assert.assertFalse(baseEventFilter.isBlackListed(new MapEvent(ImmutableMap.of("B", "B3"))));
+
+    Assert.assertFalse(baseEventFilter.isBlackListed(new MapEvent(ImmutableMap.of("C", "C1"))));
+    Assert.assertFalse(baseEventFilter.isBlackListed(new MapEvent(ImmutableMap.of("C", "C2"))));
+
+    Assert.assertFalse(baseEventFilter.isBlackListed(new MapEvent(ImmutableMap.of("D", "D1"))));
+  }
+
+  @Test
+  public void shouldBeSkippedTest()
+  {
+    final MultiBWListEventFilter baseEventFilter = new MultiBWListEventFilter(
+        ImmutableMap.of(
+            "A", Collections.singletonList("A1"),
+            "B", Arrays.asList("B1", "B2"),
+            "C", new ArrayList<>()
+        ),
+        ImmutableMap.of(
+            "A", Collections.singletonList("A2"),
+            "B", Arrays.asList("B3", "B4"),
+            "C", new ArrayList<>()
+        )
+    );
+    Assert.assertFalse(baseEventFilter.isNotListed(new MapEvent(ImmutableMap.of("A", "A1"))));
+    Assert.assertTrue(baseEventFilter.isNotListed(new MapEvent(ImmutableMap.of("A", "A2"))));
+    Assert.assertTrue(baseEventFilter.isNotListed(new MapEvent(ImmutableMap.of("A", "A3"))));
+
+    Assert.assertFalse(baseEventFilter.isNotListed(new MapEvent(ImmutableMap.of("B", "B1"))));
+    Assert.assertFalse(baseEventFilter.isNotListed(new MapEvent(ImmutableMap.of("B", "B2"))));
+    Assert.assertTrue(baseEventFilter.isNotListed(new MapEvent(ImmutableMap.of("B", "B3"))));
+    Assert.assertTrue(baseEventFilter.isNotListed(new MapEvent(ImmutableMap.of("B", "B4"))));
+    Assert.assertTrue(baseEventFilter.isNotListed(new MapEvent(ImmutableMap.of("B", "B5"))));
+
+    Assert.assertTrue(baseEventFilter.isNotListed(new MapEvent(ImmutableMap.of("C", "C1"))));
+    Assert.assertTrue(baseEventFilter.isNotListed(new MapEvent(ImmutableMap.of("C", "C2"))));
+
+    Assert.assertFalse(baseEventFilter.isNotListed(new MapEvent(ImmutableMap.of("D", "D1"))));
+  }
+
+}


### PR DESCRIPTION
Goal: skip emitting events based on some filter
Solution: black and white value lists of event fields

This feature is needed for a composing emitter to split events pipeline among different emitters.

The example configuration of a white list of a field `feed`:
```properties
whiteList.feed=A,B,C
```
This allows emitting only events whose `feed` field is either A, B, C or omitted.

The example configuration of white lists of fields `feed`, `env`:
```properties
whiteList.feed=A,B
whiteList.env=C,D
```
This allows emitting only events whose `feed` field is either A, B or omitted and `env` field is either C,D or omitted.

The example configuration of a black list of a field `feed`:
```properties
blackList.feed=A,B,C
```
This skips emitting events whose `feed` field is either A, B or C. 

The example configuration of black lists of fields `feed`, `env`:
```properties
blackList.feed=A,B
blackList.env=C,D
```
This skips emitting events whose `feed` field is either A or B or `env` field is either C or D.

White and black lists might be mixed (but don't know where that might be helpful).

B&W lists are implemented only for parametrized emitter because it is an extension of HTTP emitter and HTTP emitter configuration has some legacy that may complicate the implementation.
