### PR TITLE
Composing emitter property-based configuration

### DIFF
--- a/src/main/java/com/metamx/emitter/core/ComposingEmitter.java
+++ b/src/main/java/com/metamx/emitter/core/ComposingEmitter.java
@@ -1,21 +1,21 @@
 /*
-* Licensed to Metamarkets Group Inc. (Metamarkets) under one
-* or more contributor license agreements. See the NOTICE file
-* distributed with this work for additional information
-* regarding copyright ownership. Metamarkets licenses this file
-* to you under the Apache License, Version 2.0 (the
-* "License"); you may not use this file except in compliance
-* with the License. You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied. See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 package com.metamx.emitter.core;
 
@@ -26,16 +26,29 @@ import com.metamx.common.logger.Logger;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class ComposingEmitter implements Emitter
 {
   private static Logger log = new Logger(ComposingEmitter.class);
 
-  private final List<Emitter> emitters;
+  private final Map<String, Emitter> emitters;
+
+  public ComposingEmitter(Map<String, Emitter> emitters)
+  {
+    this.emitters = Preconditions.checkNotNull(emitters, "null emitters");
+  }
 
   public ComposingEmitter(List<Emitter> emitters)
   {
-    this.emitters = Preconditions.checkNotNull(emitters, "null emitters");
+    this.emitters = emitters.stream().collect(
+        Collectors.toMap(
+            // Default toString implementation to make the key be unique
+            e -> e.getClass().getName() + "@" + Integer.toHexString(e.hashCode()),
+            e -> e
+        )
+    );
   }
 
   @Override
@@ -44,16 +57,16 @@ public class ComposingEmitter implements Emitter
   {
     log.info("Starting Composing Emitter.");
 
-    for (Emitter e : emitters) {
-      log.info("Starting emitter %s.", e.getClass().getName());
-      e.start();
+    for (Map.Entry<String, Emitter> e : emitters.entrySet()) {
+      log.info("Starting emitter [%s].", e.getKey());
+      e.getValue().start();
     }
   }
 
   @Override
   public void emit(Event event)
   {
-    for (Emitter e : emitters) {
+    for (Emitter e : emitters.values()) {
       e.emit(event);
     }
   }
@@ -64,17 +77,18 @@ public class ComposingEmitter implements Emitter
     boolean fail = false;
     log.info("Flushing Composing Emitter.");
 
-    for (Emitter e : emitters) {
+    for (Map.Entry<String, Emitter> e : emitters.entrySet()) {
       try {
-        log.info("Flushing emitter %s.", e.getClass().getName());
-        e.flush();
-      } catch (IOException ex) {
-        log.error(ex, "Failed to flush emitter [%s]", e.getClass().getName());
+        log.info("Flushing emitter [%s].", e.getKey());
+        e.getValue().flush();
+      }
+      catch (IOException ex) {
+        log.error(ex, "Failed to flush emitter [%s]", e.getKey());
         fail = true;
       }
     }
 
-    if(fail) {
+    if (fail) {
       throw new IOException("failed to flush one or more emitters");
     }
   }
@@ -86,18 +100,18 @@ public class ComposingEmitter implements Emitter
     boolean fail = false;
     log.info("Closing Composing Emitter.");
 
-    for (Emitter e : emitters) {
+    for (Map.Entry<String, Emitter> e : emitters.entrySet()) {
       try {
-        log.info("Closing emitter %s.", e.getClass().getName());
-        e.close();
+        log.info("Closing emitter [%s].", e.getKey());
+        e.getValue().close();
       }
       catch (IOException ex) {
-        log.error(ex, "Failed to close emitter [%s]", e.getClass().getName());
+        log.error(ex, "Failed to close emitter [%s]", e.getKey());
         fail = true;
       }
     }
 
-    if(fail) {
+    if (fail) {
       throw new IOException("failed to close one or more emitters");
     }
   }

--- a/src/main/java/com/metamx/emitter/core/ComposingEmitter.java
+++ b/src/main/java/com/metamx/emitter/core/ComposingEmitter.java
@@ -1,21 +1,21 @@
 /*
- * Licensed to Metamarkets Group Inc. (Metamarkets) under one
- * or more contributor license agreements. See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership. Metamarkets licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
+* Licensed to Metamarkets Group Inc. (Metamarkets) under one
+* or more contributor license agreements. See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership. Metamarkets licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
 
 package com.metamx.emitter.core;
 

--- a/src/main/java/com/metamx/emitter/core/ComposingEmitterConfig.java
+++ b/src/main/java/com/metamx/emitter/core/ComposingEmitterConfig.java
@@ -1,0 +1,17 @@
+package com.metamx.emitter.core;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+public class ComposingEmitterConfig
+{
+  @JsonProperty("composite")
+  private Map<String, Map<String, Object>> emitterConfigs = ImmutableMap.of();
+
+  public Map<String, Map<String, Object>> getEmitterConfigs()
+  {
+    return emitterConfigs;
+  }
+}

--- a/src/main/java/com/metamx/emitter/core/ComposingEmitterConfig.java
+++ b/src/main/java/com/metamx/emitter/core/ComposingEmitterConfig.java
@@ -7,7 +7,7 @@ import java.util.Map;
 
 public class ComposingEmitterConfig
 {
-  @JsonProperty("composite")
+  @JsonProperty("composing")
   private Map<String, Map<String, Object>> emitterConfigs = ImmutableMap.of();
 
   public Map<String, Map<String, Object>> getEmitterConfigs()

--- a/src/main/java/com/metamx/emitter/core/factory/ComposingEmitterFactory.java
+++ b/src/main/java/com/metamx/emitter/core/factory/ComposingEmitterFactory.java
@@ -1,0 +1,32 @@
+package com.metamx.emitter.core.factory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.metamx.common.lifecycle.Lifecycle;
+import com.metamx.emitter.core.ComposingEmitter;
+import com.metamx.emitter.core.ComposingEmitterConfig;
+import com.metamx.emitter.core.Emitter;
+import org.asynchttpclient.AsyncHttpClient;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class ComposingEmitterFactory extends ComposingEmitterConfig implements EmitterFactory
+{
+  @Override
+  public Emitter makeEmitter(
+      ObjectMapper objectMapper,
+      AsyncHttpClient httpClient,
+      Lifecycle lifecycle
+  )
+  {
+    final Map<String, Emitter> emitters = getEmitterConfigs()
+        .entrySet()
+        .stream()
+        .collect(Collectors.toMap(
+            Map.Entry::getKey,
+            e -> objectMapper.convertValue(e.getValue(), EmitterFactory.class)
+                             .makeEmitter(objectMapper, httpClient, lifecycle)
+        ));
+    return new ComposingEmitter(emitters);
+  }
+}

--- a/src/main/java/com/metamx/emitter/core/factory/EmitterFactory.java
+++ b/src/main/java/com/metamx/emitter/core/factory/EmitterFactory.java
@@ -12,6 +12,7 @@ import org.asynchttpclient.AsyncHttpClient;
     @JsonSubTypes.Type(name = "http", value = HttpEmitterFactory.class),
     @JsonSubTypes.Type(name = "logging", value = LoggingEmitterFactory.class),
     @JsonSubTypes.Type(name = "parametrized", value = ParametrizedUriEmitterFactory.class),
+    @JsonSubTypes.Type(name = "composing", value = ComposingEmitterFactory.class),
     @JsonSubTypes.Type(name = "noop", value = NoopEmiterFactory.class),
 })
 public interface EmitterFactory

--- a/src/test/java/com/metamx/emitter/core/ComposingEmitterWithParametrizedTest.java
+++ b/src/test/java/com/metamx/emitter/core/ComposingEmitterWithParametrizedTest.java
@@ -50,12 +50,12 @@ public class ComposingEmitterWithParametrizedTest
   {
     final Properties props = new Properties();
     props.setProperty("com.metamx.emitter.type", "composing");
-    props.setProperty("com.metamx.emitter.composite.noop.type", "noop");
-    props.setProperty("com.metamx.emitter.composite.log.type", "logging");
-    props.setProperty("com.metamx.emitter.composite.http1.type", "parametrized");
-    props.setProperty("com.metamx.emitter.composite.http1.recipientBaseUrlPattern", "http://example.com/{feed}");
-    props.setProperty("com.metamx.emitter.composite.http2.type", "parametrized");
-    props.setProperty("com.metamx.emitter.composite.http2.recipientBaseUrlPattern", "http://example.com/{feed}");
+    props.setProperty("com.metamx.emitter.composing.noop.type", "noop");
+    props.setProperty("com.metamx.emitter.composing.log.type", "logging");
+    props.setProperty("com.metamx.emitter.composing.http1.type", "parametrized");
+    props.setProperty("com.metamx.emitter.composing.http1.recipientBaseUrlPattern", "http://example.com/{feed}");
+    props.setProperty("com.metamx.emitter.composing.http2.type", "parametrized");
+    props.setProperty("com.metamx.emitter.composing.http2.recipientBaseUrlPattern", "http://example.com/{feed}");
     props.putAll(overrideProps);
     lifecycle = new Lifecycle();
     Emitter emitter = Emitters.create(props, httpClient, lifecycle);

--- a/src/test/java/com/metamx/emitter/core/ComposingEmitterWithParametrizedTest.java
+++ b/src/test/java/com/metamx/emitter/core/ComposingEmitterWithParametrizedTest.java
@@ -1,0 +1,116 @@
+package com.metamx.emitter.core;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Charsets;
+import com.metamx.common.lifecycle.Lifecycle;
+import com.metamx.emitter.service.UnitEvent;
+import org.asynchttpclient.ListenableFuture;
+import org.asynchttpclient.Request;
+import org.asynchttpclient.Response;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+
+import static com.metamx.emitter.core.EmitterTest.okResponse;
+import static org.junit.Assert.assertEquals;
+
+public class ComposingEmitterWithParametrizedTest
+{
+  private static final ObjectMapper jsonMapper = new ObjectMapper();
+
+  private MockHttpClient httpClient;
+  private Lifecycle lifecycle;
+
+  @Before
+  public void setUp()
+  {
+    httpClient = new MockHttpClient();
+  }
+
+  @After
+  public void tearDown()
+  {
+    if (lifecycle != null) {
+      lifecycle.stop();
+    }
+  }
+
+  private Emitter composingEmitter() throws Exception
+  {
+    return composingEmitter(new Properties());
+  }
+
+  private Emitter composingEmitter(Properties overrideProps) throws Exception
+  {
+    final Properties props = new Properties();
+    props.setProperty("com.metamx.emitter.type", "composing");
+    props.setProperty("com.metamx.emitter.composite.noop.type", "noop");
+    props.setProperty("com.metamx.emitter.composite.log.type", "logging");
+    props.setProperty("com.metamx.emitter.composite.http1.type", "parametrized");
+    props.setProperty("com.metamx.emitter.composite.http1.recipientBaseUrlPattern", "http://example.com/{feed}");
+    props.setProperty("com.metamx.emitter.composite.http2.type", "parametrized");
+    props.setProperty("com.metamx.emitter.composite.http2.recipientBaseUrlPattern", "http://example.com/{feed}");
+    props.putAll(overrideProps);
+    lifecycle = new Lifecycle();
+    Emitter emitter = Emitters.create(props, httpClient, lifecycle);
+    assertEquals(ComposingEmitter.class, emitter.getClass());
+    lifecycle.start();
+    return emitter;
+  }
+
+  @Test
+  public void testComposingEmitterCreated() throws Exception
+  {
+    composingEmitter();
+  }
+
+
+  @Test
+  public void testComposingEmitterWithTwoParametrized() throws Exception
+  {
+    final Properties props = new Properties();
+    Emitter emitter = composingEmitter(props);
+    final List<UnitEvent> events = Arrays.asList(
+        new UnitEvent("test1", 1),
+        new UnitEvent("test2", 2)
+    );
+
+    httpClient.setGoHandler(
+        new GoHandler()
+        {
+          @Override
+          public ListenableFuture<Response> go(Request request) throws JsonProcessingException
+          {
+            switch (request.getUrl()) {
+              case "http://example.com/test1" :
+                Assert.assertEquals(
+                    String.format("[%s]\n",jsonMapper.writeValueAsString(events.get(0))),
+                    Charsets.UTF_8.decode(request.getByteBufferData().slice()).toString()
+                );
+                break;
+              case "http://example.com/test2" :
+                Assert.assertEquals(
+                    String.format("[%s]\n",jsonMapper.writeValueAsString(events.get(1))),
+                    Charsets.UTF_8.decode(request.getByteBufferData().slice()).toString()
+                );
+                break;
+            }
+            return GoHandlers.immediateFuture(okResponse());
+          }
+        }.times(4)
+    );
+
+    for (Event event : events) {
+      emitter.emit(event);
+    }
+    emitter.flush();
+    Assert.assertTrue(httpClient.succeeded());
+  }
+
+}


### PR DESCRIPTION
Goal: configure composing emitter using properties
The example of configuration:
```properties
com.metamx.emitter.type=composing
com.metamx.emitter.composing.noop.type=noop
com.metamx.emitter.composing.log.type=logging
com.metamx.emitter.composing.http1.type=parametrized
com.metamx.emitter.composing.http1.recipientBaseUrlPattern=http://example.com/{feed}
com.metamx.emitter.composing.http2.type=parametrized
com.metamx.emitter.composing.http2.recipientBaseUrlPattern=http://example.com/{feed}
```